### PR TITLE
[SC-64] Setup access for deploying synapse login app

### DIFF
--- a/config/scipoolprod/synapse-login-scipoolprod-base.yaml
+++ b/config/scipoolprod/synapse-login-scipoolprod-base.yaml
@@ -1,0 +1,9 @@
+template_path: base.yaml
+stack_name: synapse-login-scipoolprod-base
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  DNSDomainName: "scipoolprod.org"
+  BeanstalkAppName: "synapse-login"

--- a/config/scipoolprod/synapse-login-scipoolprod.yaml
+++ b/config/scipoolprod/synapse-login-scipoolprod.yaml
@@ -1,0 +1,21 @@
+template_path: app.yaml
+stack_name: synapse-login-scipoolprod
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+depedencies:
+  - scipoolprod/synapse-login-scipoolprod-base.yaml
+parameters:
+  AppDeployBucketName: "org-sagebase-scipoolprod-synapse-login-scipoolprod"
+  SnsBounceNotificationEndpoint: "aws.scipoolprod@sagebase.org"
+  SnsNotificationEndpoint: "aws.scipoolprod@sagebase.org"
+  DNSHostname: "synapse-login-scipoolprod"
+  DNSDomain: "scipoolprod.org"
+  EC2InstanceType: "t3.nano"
+  VpcName: "internalpoolvpc"
+  SessionTimeoutSeconds: "28800"
+  SynapseOauthClientId: "100050"
+  SynapseOauthClientSecret: !ssm /synapse-login-scipoolprod/SynapseOauthClientSecret
+  TeamToRoleArnMap: '[{"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}]'
+  SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8 Java 8'

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -83,6 +83,10 @@ Parameters:
   TeamToRoleArnMap:
     Type: String
     Description: The mapping of Synapse team to AWS role
+  SolutionStackName:
+    Type: String
+    Description: The Beanstalk solution stack for the app
+    Default: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8.5 Java 8'
 Resources:
   LoadBalancerAccessLogsBucket:
     Type: 'AWS::S3::Bucket'
@@ -109,8 +113,8 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
     Properties:
       ApplicationName: !ImportValue
-                       'Fn::Sub': '${AWS::Region}-synapse-login-base-BeanstalkAppName'
-      SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8.5 Java 8'
+                       'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-BeanstalkAppName'
+      SolutionStackName: !Ref SolutionStackName
       OptionSettings:
         # EB environment options
         - Namespace: 'aws:autoscaling:asg'
@@ -185,7 +189,7 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: ServiceRole
           Value: !ImportValue
-                'Fn::Sub': '${AWS::Region}-synapse-login-base-BeanstalkServiceRole'
+                'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-BeanstalkServiceRole'
         - Namespace: 'aws:elasticbeanstalk:environment:process:default'
           OptionName: Protocol
           Value: 'HTTP'
@@ -219,7 +223,7 @@ Resources:
         - Namespace: 'aws:elbv2:listener:443'
           OptionName: SSLCertificateArns
           Value: !ImportValue
-                 'Fn::Sub': '${AWS::Region}-synapse-login-base-SSLCertificate'
+                 'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-SSLCertificate'
         # Application environment options
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SESSION_TIMEOUT_SECONDS
@@ -240,7 +244,7 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:
       ApplicationName: !ImportValue
-                       'Fn::Sub': '${AWS::Region}-synapse-login-base-BeanstalkAppName'
+                       'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-BeanstalkAppName'
       TemplateName: !Ref BeanstalkConfigurationTemplate
       EnvironmentName: !Join
         - '-'
@@ -457,22 +461,75 @@ Resources:
           - !Ref 'AWS::StackName'
           - var/log/tomcat8/catalina.out
       RetentionInDays: 90
-  AppServiceUserAccessKey:
+  ServiceUser:
+    Type: 'AWS::IAM::User'
+  ServiceUserAccessKey:
     Type: 'AWS::IAM::AccessKey'
     Properties:
-      UserName: !Ref AppServiceUser
-  AppServiceUser:
-    Type: 'AWS::IAM::User'
+      UserName: !Ref ServiceUser
+  ServiceRole:
+    Type: "AWS::IAM::Role"
     Properties:
-      Groups:
-        - !Ref AppServiceUserGroup
-  AppServiceUserGroup:
-    Type: 'AWS::IAM::Group'
-    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !ImportValue {'Fn::Sub': '${AWS::Region}-bootstrap-TravisUserArn'}
+                - !GetAtt ServiceUser.Arn
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/AmazonSNSFullAccess
-        - arn:aws:iam::aws:policy/AmazonSESFullAccess
+        - !Ref ServicePolicy
+  # Enable management of elastic beanstalk app
+  # https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.managed-policies.html
+  ServicePolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Deny
+            Action:
+              - elasticbeanstalk:CreateApplication
+              - elasticbeanstalk:DeleteApplication
+            Resource:
+              - "*"
+          - Effect: Deny
+            Action:
+              - elasticbeanstalk:CreateApplicationVersion
+              - elasticbeanstalk:CreateConfigurationTemplate
+              - elasticbeanstalk:CreateEnvironment
+              - elasticbeanstalk:DeleteApplicationVersion
+              - elasticbeanstalk:DeleteConfigurationTemplate
+              - elasticbeanstalk:DeleteEnvironmentConfiguration
+              - elasticbeanstalk:DescribeApplicationVersions
+              - elasticbeanstalk:DescribeConfigurationOptions
+              - elasticbeanstalk:DescribeConfigurationSettings
+              - elasticbeanstalk:DescribeEnvironmentResources
+              - elasticbeanstalk:DescribeEnvironments
+              - elasticbeanstalk:DescribeEvents
+              - elasticbeanstalk:DeleteEnvironmentConfiguration
+              - elasticbeanstalk:RebuildEnvironment
+              - elasticbeanstalk:RequestEnvironmentInfo
+              - elasticbeanstalk:RestartAppServer
+              - elasticbeanstalk:RetrieveEnvironmentInfo
+              - elasticbeanstalk:SwapEnvironmentCNAMEs
+              - elasticbeanstalk:TerminateEnvironment
+              - elasticbeanstalk:UpdateApplicationVersion
+              - elasticbeanstalk:UpdateConfigurationTemplate
+              - elasticbeanstalk:UpdateEnvironment
+              - elasticbeanstalk:RetrieveEnvironmentInfo
+              - elasticbeanstalk:ValidateConfigurationSettings
+            Resource:
+              - "*"
+            Condition:
+              StringNotEquals:
+                elasticbeanstalk:InApplication:
+                  - !Sub 'arn:aws:elasticbeanstalk:${AWS::Region}:${AWS::AccountId}:application/${AWS::StackName}'
   KmsKey:
     Type: "AWS::KMS::Key"
     Properties:
@@ -521,9 +578,9 @@ Resources:
                     - ':root'
                 - !ImportValue
                   'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
-                - !GetAtt AppServiceUser.Arn
+                - !GetAtt ServiceUser.Arn
                 - !ImportValue
-                  'Fn::Sub': '${AWS::Region}-synapse-login-base-BeanstalkServiceRoleArn'
+                  'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-BeanstalkServiceRoleArn'
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"
@@ -579,11 +636,27 @@ Outputs:
     Value: !Ref InstanceSecurityGroup
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-InstanceSecurityGroup'
-  AppServiceUserAccessKey:
-    Value: !Ref AppServiceUserAccessKey
+  ServiceUser:
+    Value: !Ref ServiceUser
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-AppServiceUserAccessKey'
-  AppServiceUserSecretAccessKey:
-    Value: !GetAtt AppServiceUserAccessKey.SecretAccessKey
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUser'
+  ServiceUserArn:
+    Value: !GetAtt ServiceUser.Arn
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-AppServiceUserSecretAccessKey'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserArn'
+  ServiceUserAccessKey:
+    Value: !Ref ServiceUserAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserAccessKey'
+  ServiceUserSecretAccessKey:
+    Value: !GetAtt ServiceUserAccessKey.SecretAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserSecretAccessKey'
+  ServiceRole:
+    Value: !Ref ServiceRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRole'
+  ServiceRoleArn:
+    Value: !GetAtt ServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRoleArn'

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -483,53 +483,84 @@ Resources:
               - "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
-        - !Ref ServicePolicy
-  # Enable management of elastic beanstalk app
-  # https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.managed-policies.html
-  ServicePolicy:
+        - !Ref AppDeveloperPolicy
+        - !Ref BeanstalkDeveloperPolicy
+  # policies for service role
+  # https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.example.resource.html
+  AppDeveloperPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Effect: Deny
+          - Effect: Allow
             Action:
-              - elasticbeanstalk:CreateApplication
-              - elasticbeanstalk:DeleteApplication
-            Resource:
-              - "*"
-          - Effect: Deny
+              - ec2:*
+              - elasticloadbalancing:*
+              - autoscaling:*
+              - cloudwatch:*
+              - s3:*
+              - sns:*
+              - rds:*
+              - cloudformation:*
+            Resource: "*"
+  BeanstalkDeveloperPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllReadCallsAndAllVersionCallsInApplications
             Action:
-              - elasticbeanstalk:CreateApplicationVersion
-              - elasticbeanstalk:CreateConfigurationTemplate
-              - elasticbeanstalk:CreateEnvironment
-              - elasticbeanstalk:DeleteApplicationVersion
-              - elasticbeanstalk:DeleteConfigurationTemplate
-              - elasticbeanstalk:DeleteEnvironmentConfiguration
-              - elasticbeanstalk:DescribeApplicationVersions
-              - elasticbeanstalk:DescribeConfigurationOptions
-              - elasticbeanstalk:DescribeConfigurationSettings
-              - elasticbeanstalk:DescribeEnvironmentResources
-              - elasticbeanstalk:DescribeEnvironments
-              - elasticbeanstalk:DescribeEvents
-              - elasticbeanstalk:DeleteEnvironmentConfiguration
-              - elasticbeanstalk:RebuildEnvironment
+              - elasticbeanstalk:Describe*
               - elasticbeanstalk:RequestEnvironmentInfo
-              - elasticbeanstalk:RestartAppServer
               - elasticbeanstalk:RetrieveEnvironmentInfo
-              - elasticbeanstalk:SwapEnvironmentCNAMEs
-              - elasticbeanstalk:TerminateEnvironment
+              - elasticbeanstalk:CreateApplicationVersion
+              - elasticbeanstalk:DeleteApplicationVersion
               - elasticbeanstalk:UpdateApplicationVersion
-              - elasticbeanstalk:UpdateConfigurationTemplate
-              - elasticbeanstalk:UpdateEnvironment
-              - elasticbeanstalk:RetrieveEnvironmentInfo
-              - elasticbeanstalk:ValidateConfigurationSettings
+            Effect: Allow
             Resource:
               - "*"
             Condition:
-              StringNotEquals:
+              StringEquals:
                 elasticbeanstalk:InApplication:
                   - !Sub 'arn:aws:elasticbeanstalk:${AWS::Region}:${AWS::AccountId}:application/${AWS::StackName}'
+          - Sid: AllReadCallsOnApplications
+            Action:
+              - elasticbeanstalk:DescribeApplications
+              - elasticbeanstalk:DescribeEvents
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:elasticbeanstalk:${AWS::Region}:${AWS::AccountId}:application/${AWS::StackName}'
+          - Sid: UpdateEnvironmentInApplications
+            Action:
+              - elasticbeanstalk:UpdateEnvironment
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:elasticbeanstalk:${AWS::Region}:${AWS::AccountId}:application/${AWS::StackName}'
+              - arn:aws:elasticbeanstalk:us-east-2:123456789012:environment/app1/app1-staging*
+            Condition:
+              StringEquals:
+                elasticbeanstalk:InApplication:
+                  - !Sub 'arn:aws:elasticbeanstalk:${AWS::Region}:${AWS::AccountId}:application/${AWS::StackName}'
+              StringLike:
+                elasticbeanstalk:FromApplicationVersion:
+                  - !Sub 'arn:aws:elasticbeanstalk:${AWS::Region}:${AWS::AccountId}:application/${AWS::StackName}/*'
+          - Sid: AllReadCallsOnSolutionStacks
+            Action:
+              - elasticbeanstalk:ListAvailableSolutionStacks
+              - elasticbeanstalk:DescribeConfigurationOptions
+              - elasticbeanstalk:ValidateConfigurationSettings
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:elasticbeanstalk:${AWS::Region}::solutionstack/*'
+          - Sid: AllNonResourceCalls
+            Action:
+              - elasticbeanstalk:CheckDNSAvailability
+              - elasticbeanstalk:CreateStorageLocation
+            Effect: Allow
+            Resource:
+              - "*"
   KmsKey:
     Type: "AWS::KMS::Key"
     Properties:

--- a/templates/base.yaml
+++ b/templates/base.yaml
@@ -4,6 +4,9 @@ Parameters:
   DNSDomainName:
     Description: DNS Domain name for application
     Type: String
+  BeanstalkAppName:
+    Description: DNS Domain name for application
+    Type: String
 Resources:
   BeanstalkServiceRole:
     Type: 'AWS::IAM::Role'
@@ -28,7 +31,7 @@ Resources:
   BeanstalkApplication:
     Type: 'AWS::ElasticBeanstalk::Application'
     Properties:
-      ApplicationName: 'synapse-login-sc'
+      ApplicationName: !Ref BeanstalkAppName
       ResourceLifecycleConfig:
         ServiceRole: !GetAtt BeanstalkServiceRole.Arn
         VersionLifecycleConfig:


### PR DESCRIPTION
* Rename Beanstalk application and environment to make it easier to
  deploy multiple synapse login apps.
* Create a service user/role combination to allow a CI service
 (i.e.travis) to deploy synapse login apps
 (i.e. https://github.com/Sage-Bionetworks/synapse-login-scipoolprod)