### PR TITLE
[SC-64] move app parameters to file

### DIFF
--- a/config/scipoolprod/synapse-login-scipoolprod.yaml
+++ b/config/scipoolprod/synapse-login-scipoolprod.yaml
@@ -14,8 +14,5 @@ parameters:
   DNSDomain: "scipoolprod.org"
   EC2InstanceType: "t3.nano"
   VpcName: "internalpoolvpc"
-  SessionTimeoutSeconds: "28800"
-  SynapseOauthClientId: "100050"
   SynapseOauthClientSecret: !ssm /synapse-login-scipoolprod/SynapseOauthClientSecret
-  TeamToRoleArnMap: '[{"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}]'
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8 Java 8'

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -67,22 +67,10 @@ Parameters:
   VpcName:
     Type: String
     Description: The VPC for this application
-  SessionTimeoutSeconds:
-    Type: Number
-    Description: The login session timeout in seconds
-    Default: 14400
-    MinValue: 3600
-    MaxValue: 43200
-  SynapseOauthClientId:
-    Type: String
-    Description: The OAuth client registered with Synapse that enables BSM sign in via Synapse
   SynapseOauthClientSecret:
     Type: String
     NoEcho: true
     Description: The OAuth client registered with Synapse that enables BSM sign in via Synapse
-  TeamToRoleArnMap:
-    Type: String
-    Description: The mapping of Synapse team to AWS role
   SolutionStackName:
     Type: String
     Description: The Beanstalk solution stack for the app
@@ -226,20 +214,8 @@ Resources:
                  'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-SSLCertificate'
         # Application environment options
         - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: SESSION_TIMEOUT_SECONDS
-          Value: !Ref SessionTimeoutSeconds
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: AWS_REGION
-          Value: !Ref AWS::Region
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: SYNAPSE_OAUTH_CLIENT_ID
-          Value: !Ref SynapseOauthClientId
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SYNAPSE_OAUTH_CLIENT_SECRET
           Value: !Ref SynapseOauthClientSecret
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: TEAM_TO_ROLE_ARN_MAP
-          Value: !Ref TeamToRoleArnMap
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
We are moving synapse login app configs from beanstalk environment vars
to global.properties due to an issue where Beanstalk stripping quotes
from json strings when read from beanstalk env vars. Stripping quotes
makes the json invalid which causes the app to fail.  We keep
SYNAPSE_OAUTH_CLIENT_SECRET param here so we can inject it's value
from the AWS SSM.

More info about the beanstalk issue here:
 https://stackoverflow.com/questions/26553553/json-stored-in-aws-eb-environment-variables-is-retrieved-without-quote

This PR depends on PR https://github.com/Sage-Bionetworks/synapse-login-scipoolprod/pull/13