### PR TITLE
[SC-64] Monitor application health

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -6,7 +6,7 @@ Parameters:
   AppHealthcheckUrl:
     Type: String
     Description: The AWS EB health check path
-    Default: "/"
+    Default: "/health"
   AutoScalingMaxSize:
     Type: Number
     Default: 1
@@ -291,10 +291,15 @@ Resources:
     DependsOn: Route53RecordSet
     Properties:
       HealthCheckConfig:
-        FullyQualifiedDomainName: !GetAtt BeanstalkEnvironment.EndpointURL
+        FullyQualifiedDomainName: !Join
+          - ''
+          - - 'https://'
+            - !Ref DNSHostname
+            - .
+            - !Ref DNSDomain
         Port: 443
         Type: "HTTPS"
-        ResourcePath: "/"
+        ResourcePath: !Ref AppHealthcheckUrl
       HealthCheckTags:
         -
           Key: "Name"


### PR DESCRIPTION
A health check endpoint was implemented
in PR https://github.com/Sage-Bionetworks/synapse-login-scipoolprod/pull/18
so now we can tell beanstalk to monitor our application for
us by enabling health checks.