### PR TITLE
[SC-64] app scale out

### DIFF
--- a/config/scipoolprod/synapse-login-scipoolprod.yaml
+++ b/config/scipoolprod/synapse-login-scipoolprod.yaml
@@ -16,3 +16,5 @@ parameters:
   VpcName: "internalpoolvpc"
   SynapseOauthClientSecret: !ssm /synapse-login-scipoolprod/SynapseOauthClientSecret
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8 Java 8'
+  AutoScalingMinSize: 2
+  AutoScalingMaxSize: 3


### PR DESCRIPTION
Increase the number of instances to handle load on the app. Make
sure there are at least two t3.small instances running at all
times.