### PR TITLE
Setup SSH keypair

### DIFF
--- a/config/scipoolprod/synapse-login-scipoolprod.yaml
+++ b/config/scipoolprod/synapse-login-scipoolprod.yaml
@@ -13,6 +13,7 @@ parameters:
   DNSHostname: "synapse-login-scipoolprod"
   DNSDomain: "scipoolprod.org"
   EC2InstanceType: "t3.small"
+  EC2KeyName: 'scipoolprod'
   VpcName: "internalpoolvpc"
   SynapseOauthClientSecret: !ssm /synapse-login-scipoolprod/SynapseOauthClientSecret
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8 Java 8'

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -49,6 +49,9 @@ Parameters:
       - t3.large
       - t3.xlarge
       - t3.2xlarge
+  EC2KeyName:
+    Description: An existing EC2 keypair to allow secure access to instances
+    Type: String
   RollingUpdateType:
     Type: String
     Default: "Time"
@@ -120,6 +123,9 @@ Resources:
         - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: SecurityGroups
           Value: !Ref InstanceSecurityGroup
+        - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: EC2KeyName
+          Value: !Ref EC2KeyName
         - Namespace: 'aws:autoscaling:updatepolicy:rollingupdate'
           OptionName: RollingUpdateEnabled
           Value: 'true'


### PR DESCRIPTION
Apply an SSH keypair to instances to allow admin access
in case things go sideways.