### PR TITLE
[SC-101] use PROPERTIES_FILENAME env var

### DIFF
--- a/config/scipoolprod/synapse-login-scipoolprod.yaml
+++ b/config/scipoolprod/synapse-login-scipoolprod.yaml
@@ -19,3 +19,4 @@ parameters:
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8 Java 8'
   AutoScalingMinSize: "2"
   AutoScalingMaxSize: "3"
+  PropertiesFilename: "scipoolprod.properties"

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -78,6 +78,10 @@ Parameters:
     Type: String
     Description: The Beanstalk solution stack for the app
     Default: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8.5 Java 8'
+  PropertiesFilename:
+    Type: String
+    Description: The name of the app configuration file to load
+    Default: 'global.properties'
 Resources:
   LoadBalancerAccessLogsBucket:
     Type: 'AWS::S3::Bucket'
@@ -222,6 +226,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SYNAPSE_OAUTH_CLIENT_SECRET
           Value: !Ref SynapseOauthClientSecret
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: PROPERTIES_FILENAME
+          Value: !Ref PropertiesFilename
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
Use the new PROPERTIES_FILENAME env var to load the application
configs for scipoolprod.

the new env var was added in commit:
https://github.com/Sage-Bionetworks/synapse-login-scipoolprod/commit/2da532f2df1885926260fbe50de2e1b4918f7eb8

This PR depends on PR https://github.com/Sage-Bionetworks/synapse-login-scipoolprod/pull/23