### PR TITLE
[SC-84] Get secret from SSM

### DIFF
--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -15,7 +15,6 @@ parameters:
   EC2InstanceType: "t3.small"
   EC2KeyName: 'scipool'
   VpcName: "cesspoolvpc"
-  SynapseOauthClientSecret: !ssm /synapse-login-scipooldev/SynapseOauthClientSecret
   PropertiesFilename: "scipooldev.properties"
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8 Java 8'
   AutoScalingMinSize: "1"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -15,7 +15,6 @@ parameters:
   EC2InstanceType: "t3.small"
   EC2KeyName: 'scipool'
   VpcName: "internalpoolvpc"
-  SynapseOauthClientSecret: !ssm /synapse-login-scipoolprod/SynapseOauthClientSecret
   PropertiesFilename: "scipoolprod.properties"
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8 Java 8'
   AutoScalingMinSize: "2"


### PR DESCRIPTION
With the fix to issue https://sagebionetworks.jira.com/browse/SC-84
we no longer need to pass secrets with environment variables.  The
secret will be loaded directly from the AWS SSM.