### PR TITLE
SC-132: Add SSL cert for *.sageit.org

### DIFF
--- a/templates/base.yaml
+++ b/templates/base.yaml
@@ -53,6 +53,14 @@ Resources:
               - !Ref DNSDomainName
           ValidationDomain: !Ref DNSDomainName
       ValidationMethod: DNS
+  SSLCertificateSageIT:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: '*.sageit.org'
+      DomainValidationOptions:
+        - DomainName: '*.sageit.org'
+          ValidationDomain: 'sageit.org'
+      ValidationMethod: DNS
 Outputs:
   BeanstalkAppName:
     Value: !Ref BeanstalkApplication
@@ -70,3 +78,7 @@ Outputs:
     Value: !Ref SSLCertificate
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SSLCertificate'
+  SSLCertificateSageIT:
+    Value: !Ref SSLCertificateSageIT
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSLCertificateSageIT'


### PR DESCRIPTION
[SC-132] To support hitting the login app using 'sc-dev.sageit.org'.
Validate DNS in sageit account when done.

Note: if more than one instance of app in account, I think this should be moved to its own template or we'll end up with multiple ACM certs to '*.sageit.org'.


[SC-132]: https://sagebionetworks.jira.com/browse/SC-132