### PR TITLE
Change beanstalk to update on instance health

### DIFF
--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -20,3 +20,4 @@ parameters:
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8.5 Java 8'
   AutoScalingMinSize: "1"
   AutoScalingMaxSize: "2"
+  RollingUpdateType: "Health"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -20,3 +20,4 @@ parameters:
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8.5 Java 8'
   AutoScalingMinSize: "2"
   AutoScalingMaxSize: "3"
+  RollingUpdateType: "Health"


### PR DESCRIPTION
Change beanstalk rolling update to update only after instances are
healthy

Ref: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rollingupdates.html

* Time – Specify an amount of time to wait between launching new instances and placing them in service before starting the next batch.
* Health – Wait until instances in the current batch are healthy before placing instances in service and starting the next batch.