### PR TITLE
[SC-84] remove SYNAPSE_OAUTH_CLIENT_SECRET env var

### DIFF
--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -15,7 +15,6 @@ parameters:
   EC2InstanceType: "t3.small"
   EC2KeyName: 'scipool'
   VpcName: "cesspoolvpc"
-  SynapseOauthClientSecret: !ssm /synapse-login-scipooldev/SynapseOauthClientSecret
   PropertiesFilename: "scipooldev.properties"
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8.5 Java 8'
   AutoScalingMinSize: "1"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -15,7 +15,6 @@ parameters:
   EC2InstanceType: "t3.small"
   EC2KeyName: 'scipool'
   VpcName: "internalpoolvpc"
-  SynapseOauthClientSecret: !ssm /synapse-login-scipoolprod/SynapseOauthClientSecret
   PropertiesFilename: "scipoolprod.properties"
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8.5 Java 8'
   AutoScalingMinSize: "2"

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -70,10 +70,6 @@ Parameters:
   VpcName:
     Type: String
     Description: The VPC for this application
-  SynapseOauthClientSecret:
-    Type: String
-    NoEcho: true
-    Description: The OAuth client registered with Synapse that enables BSM sign in via Synapse
   PropertiesFilename:
     Type: String
     Description: The properties file that the application will use
@@ -223,9 +219,6 @@ Resources:
           Value: !ImportValue
                  'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-SSLCertificate'
         # Application environment options
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: SYNAPSE_OAUTH_CLIENT_SECRET
-          Value: !Ref SynapseOauthClientSecret
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: PROPERTIES_FILENAME
           Value: !Ref PropertiesFilename


### PR DESCRIPTION
Login app will retrieve SYNAPSE_OAUTH_CLIENT_SECRET value directly from
the AWS SSM so we no longer need to set it as a beanstalk environment
variable.

This PR depends on PR https://github.com/Sage-Bionetworks/synapse-login-scipool/pull/17