### PR TITLE
SC-143  Adds permission for the login app' to add session tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # synapse-login-aws-infra
-Infrastructor for the Synapse login application to the AWS service catalog
+Infrastructure for the Synapse login application to the AWS service catalog
 
 ## Deployment
 We use[sceptre](https://sceptre.cloudreach.com/latest/about.html) to deploy the
@@ -17,7 +17,7 @@ setup you can deploy the login apps into the beanstalk solution stack.
 
 # login apps
 List of login apps using this AWS infrastructure.
-* https://github.com/Sage-Bionetworks/synapse-login-scipoolprod
+* https://github.com/Sage-Bionetworks/synapse-login-scipool
 
 ## Continuous Integration
 We have configured Travis to deploy CF template updates.  Travis deploys using

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -406,9 +406,6 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - 'sts:AssumeRole'
-      TagSessionPolicyDocument:
-        Version: 2012-10-17
-        Statement:
           - Effect: Allow
             Principal:
               Service:

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -406,6 +406,15 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - 'sts:AssumeRole'
+      TagSessionPolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:TagSession'
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier'

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -406,11 +406,6 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - 'sts:AssumeRole'
-          - Effect: Allow
-            Principal:
-              Service:
-                - ec2.amazonaws.com
-            Action:
               - 'sts:TagSession'
       Path: /
       ManagedPolicyArns:


### PR DESCRIPTION
To support an upcoming change to scipool-login in which the app' will add session tags, this change to the deployment script adds the permission to add session tags.  This change is based on 
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_permissions-required
which says, "you must have the following permissions-only action in your policy: sts:TagSession"