### PR TITLE
SC-143 removing unnecessary permission

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -406,7 +406,6 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - 'sts:AssumeRole'
-              - 'sts:TagSession'
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier'


### PR DESCRIPTION
The permission introduced the previous PR is unnecessary.  The correct place to add "TagSession" permission is in the trust relationship defined for the role to be assumed.