### PR TITLE
Give access to OIDC client secret

### DIFF
--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -20,3 +20,4 @@ parameters:
   AutoScalingMinSize: "1"
   AutoScalingMaxSize: "2"
   RollingUpdateType: "Health"
+  OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -20,3 +20,4 @@ parameters:
   AutoScalingMinSize: "2"
   AutoScalingMaxSize: "3"
   RollingUpdateType: "Health"
+  OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -78,6 +78,9 @@ Parameters:
     Type: String
     Description: The Beanstalk solution stack for the app
     Default: '64bit Amazon Linux 2018.03 v3.3.3 running Tomcat 8.5 Java 8'
+  OidcClientSecretKeyName:
+    Description: 'The name of the key that stores the OAuth 2.0 client secret'
+    Type: String
 Resources:
   LoadBalancerAccessLogsBucket:
     Type: 'AWS::S3::Bucket'
@@ -342,16 +345,7 @@ Resources:
             Action:
               - 'ssm:*'
             Effect: Allow
-            Resource: !Join
-              - ''
-              - - 'arn:aws:ssm:'
-                - !Ref AWS::Region
-                - ':'
-                - !Ref AWS::AccountId
-                - ':'
-                - 'parameter/'
-                - !Ref AWS::StackName
-                - '/*'
+            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${OidcClientSecretKeyName}'
   KmsDecryptManagedPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -345,7 +345,9 @@ Resources:
             Action:
               - 'ssm:*'
             Effect: Allow
-            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${OidcClientSecretKeyName}'
+            Resource:
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/*'
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${OidcClientSecretKeyName}'
   KmsDecryptManagedPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:


### PR DESCRIPTION
Give instance running the login app access to the OIDC client secret in
the SSM.

This change was neglected as part of commit 5d25ea3e5