### PR TITLE
[SC-207] Setup Beanstalk ENV Vars

### DIFF
--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -5,6 +5,7 @@ stack_tags:
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
 depedencies:
+  - develop/synapse-login-scipooldev-params.yaml
   - develop/synapse-login-scipooldev-base.yaml
 parameters:
   AppDeployBucketName: "org-sagebase-scipooldev-synapse-login-scipooldev"

--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -16,7 +16,6 @@ parameters:
   EC2InstanceType: "t3.small"
   EC2KeyName: 'scipool'
   VpcName: "cesspoolvpc"
-  PropertiesFilename: "scipooldev.properties"
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8.5 Java 8'
   AutoScalingMinSize: "1"
   AutoScalingMaxSize: "2"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -16,7 +16,6 @@ parameters:
   EC2InstanceType: "t3.small"
   EC2KeyName: 'scipool'
   VpcName: "internalpoolvpc"
-  PropertiesFilename: "scipoolprod.properties"
   SolutionStackName: '64bit Amazon Linux 2018.03 v3.3.4 running Tomcat 8.5 Java 8'
   AutoScalingMinSize: "2"
   AutoScalingMaxSize: "3"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -5,6 +5,7 @@ stack_tags:
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
 depedencies:
+  - prod/synapse-login-scipooldev-params.yaml
   - prod/synapse-login-scipoolprod-base.yaml
 parameters:
   AppDeployBucketName: "org-sagebase-scipoolprod-synapse-login-scipoolprod"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -5,7 +5,7 @@ stack_tags:
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
 depedencies:
-  - prod/synapse-login-scipooldev-params.yaml
+  - prod/synapse-login-scipoolprod-params.yaml
   - prod/synapse-login-scipoolprod-base.yaml
 parameters:
   AppDeployBucketName: "org-sagebase-scipoolprod-synapse-login-scipoolprod"

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -225,6 +225,27 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: PROPERTIES_FILENAME
           Value: !Ref PropertiesFilename
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: SYNAPSE_OAUTH_CLIENT_ID
+          Value: "/service-catalog/SynapseOauthClientId"
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: AWS_REGION
+          Value: "/service-catalog/AwsRegion"
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: SESSION_TIMEOUT_SECONDS
+          Value: "/service-catalog/SessionTimeoutSeconds"
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: SESSION_NAME_CLAIMS
+          Value: "/service-catalog/SessionNameClaims"
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: SESSION_TAG_CLAIMS
+          Value: "/service-catalog/SessionTagClaims"
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: REDIRECT_URIS
+          Value: "/service-catalog/RedirectUris"
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: TEAM_TO_ROLE_ARN_MAP
+          Value: "/service-catalog/TeamToRoleArnMap"
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -70,10 +70,6 @@ Parameters:
   VpcName:
     Type: String
     Description: The VPC for this application
-  PropertiesFilename:
-    Type: String
-    Description: The properties file that the application will use
-    Default: "global.properties"
   SolutionStackName:
     Type: String
     Description: The Beanstalk solution stack for the app
@@ -223,29 +219,29 @@ Resources:
                  'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-SSLCertificate'
         # Application environment options
         - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: PROPERTIES_FILENAME
-          Value: !Ref PropertiesFilename
+          OptionName: SYNAPSE_OAUTH_CLIENT_SECRET
+          Value: "ssm::/service-catalog/SynapseOauthClientId"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SYNAPSE_OAUTH_CLIENT_ID
-          Value: "/service-catalog/SynapseOauthClientId"
+          Value: "ssm::/service-catalog/SynapseOauthClientId"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: AWS_REGION
-          Value: "/service-catalog/AwsRegion"
+          Value: "ssm::/service-catalog/AwsRegion"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SESSION_TIMEOUT_SECONDS
-          Value: "/service-catalog/SessionTimeoutSeconds"
+          Value: "ssm::/service-catalog/SessionTimeoutSeconds"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SESSION_NAME_CLAIMS
-          Value: "/service-catalog/SessionNameClaims"
+          Value: "ssm::/service-catalog/SessionNameClaims"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SESSION_TAG_CLAIMS
-          Value: "/service-catalog/SessionTagClaims"
+          Value: "ssm::/service-catalog/SessionTagClaims"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: REDIRECT_URIS
-          Value: "/service-catalog/RedirectUris"
+          Value: "ssm::/service-catalog/RedirectUris"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: TEAM_TO_ROLE_ARN_MAP
-          Value: "/service-catalog/TeamToRoleArnMap"
+          Value: "ssm::/service-catalog/TeamToRoleArnMap"
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
Setup beanstalk environment variables to allow the login app
to access the corresponding parameter values in the SSM parameter
store.  The idea is to move the app's configurations from
synapse-login-scipool[1] to the beanstalk container that runs
it.

[1] https://github.com/Sage-Bionetworks/synapse-login-scipool