### PR TITLE
[SC-207] give beanstalk instances access to SSM params

### DIFF
--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -21,3 +21,4 @@ parameters:
   AutoScalingMaxSize: "2"
   RollingUpdateType: "Health"
   OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"
+  SsmParameterPrefix: !stack_output_external synapse-login-scipooldev-params::Prefix

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -21,3 +21,4 @@ parameters:
   AutoScalingMaxSize: "3"
   RollingUpdateType: "Health"
   OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"
+  SsmParameterPrefix: !stack_output_external synapse-login-scipoolprod-params::Prefix

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -77,6 +77,10 @@ Parameters:
   OidcClientSecretKeyName:
     Description: 'The name of the key that stores the OAuth 2.0 client secret'
     Type: String
+  SsmParameterPrefix:
+    Description: 'The SSM parameter store prefix for the application variablex'
+    ConstraintDescription: 'A prefix to the params (i.e. /service-catalog/)'
+    Type: String
 Resources:
   LoadBalancerAccessLogsBucket:
     Type: 'AWS::S3::Bucket'
@@ -364,6 +368,7 @@ Resources:
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${OidcClientSecretKeyName}'
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SsmParameterPrefix}*'
   # cloudwatch integration https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
   CloudwatchIntegrationManagedPolicy:
     Type: 'AWS::IAM::ManagedPolicy'

--- a/templates/ssm-parameters.j2
+++ b/templates/ssm-parameters.j2
@@ -12,6 +12,10 @@ Resources:
         Type: 'String'
   {% endfor %}
 Outputs:
+  Prefix:
+    Value: {{ sceptre_user_data.Prefix }}
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Prefix'
   {% for parameter in sceptre_user_data.Parameters %}
   {%- set name = parameter.Name -%}
   {%- set value = parameter.Value -%}


### PR DESCRIPTION
PR #38 added params to the SSM parameter store however we forgot to give
Beanstalk instances access to those params.  This PR fixes that problem.

* Output SSM App Prefix name in template to create parameters
* Reference app prefix name and give beanstalk instances access to the
  parameters with that prefix