### PR TITLE
revert-aws-marketplace-changes

### DIFF
--- a/config/develop/synapse-login-scipooldev-params.yaml
+++ b/config/develop/synapse-login-scipooldev-params.yaml
@@ -33,5 +33,3 @@ sceptre_user_data:
           {"teamId":"3409012","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"},
           {"teamId":"3409013","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogExternalEndusers"}
         ]'
-    - Name: MarketplaceProductCodeSC
-      Value: d3xz0ef8n2bqgnuynummc21w7

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -246,13 +246,6 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: TEAM_TO_ROLE_ARN_MAP
           Value: "ssm::/service-catalog/TeamToRoleArnMap"
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: MARKETPLACE_PRODUCT_CODE_SC
-          Value: "ssm::/service-catalog/MarketplaceProductCodeSC"
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: MARKETPLACE_ID_DYNAMO_TABLE_NAME
-          Value: !ImportValue
-                 'Fn::Sub': '${AWS::Region}-marketplace-dynamo-MarketplaceDynamoDBTable'
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:
@@ -376,33 +369,6 @@ Resources:
             Resource:
               - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${OidcClientSecretKeyName}'
               - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SsmParameterPrefix}*'
-  ResolveCustomerMarketplaceManagedPolicy:
-    Type: "AWS::IAM::ManagedPolicy"
-    Properties:
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: ResolveCustomerMarketplace
-            Effect: Allow
-            Action: "aws-marketplace:ResolveCustomer"
-            Resource: "*"
-  DynamoRWManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: DynamoRW
-            Effect: 'Allow'
-            Action:
-              - 'dynamodb:*Get*'
-              - 'dynamodb:*List*'
-              - 'dynamodb:Query'
-              - 'dynamodb:*Write*'
-              - 'dynamodb:*Put*'
-            Resource:
-              - !ImportValue
-                'Fn::Sub': '${AWS::Region}-marketplace-dynamo-MarketplaceDynamoDBTableArn'
   # cloudwatch integration https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
   CloudwatchIntegrationManagedPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
@@ -443,8 +409,6 @@ Resources:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-sc-kms-key-KmsDecryptPolicyArn'
         - !Ref SsmManagedPolicy
-        - !Ref ResolveCustomerMarketplaceManagedPolicy
-        - !Ref DynamoRWManagedPolicy
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:


### PR DESCRIPTION
Revert changes for integrating AWS Marketplace in the Synapse login app, which includes removing the SSM secrets and Dynamo DB access.

This PR depends on Sage-Bionetworks/synapse-login-scipool#68