### PR TITLE
update pre-commit linters and beanstalk policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.0.1
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.17.0
+    rev: v1.26.2
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.29.0
+    rev: v0.53.0
     hooks:
     -   id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.6
+    rev: v1.1.10
     hooks:
     -   id: remove-tabs

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -460,7 +460,7 @@ Resources:
               - "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess
+        - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
 Outputs:
   AppPublicEndpoint:
     Value: !Join


### PR DESCRIPTION
* update the pre-commit linters
* update beanstalk policy, the AWSElasticBeanstalkFullAccess policy has
  been deprecated.  The new equivalent one is AdministratorAccess-AWSElasticBeanstalk[1]

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.managed-policies.html

