### PR TITLE
[SC-307] Setup infra for the synapse login app for BMGF service catalog

### DIFF
--- a/config/bmgfki/synapse-login-bmgfki-base.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-base.yaml
@@ -1,0 +1,11 @@
+template_path: base.yaml
+stack_name: synapse-login-bmgfki-base
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - bmgfki/synapse-login-bmgfki-sageit-cert.yaml
+parameters:
+  DNSDomainName: "sagebio-bmgfki.org"
+  BeanstalkAppName: "synapse-login"

--- a/config/bmgfki/synapse-login-bmgfki-extra.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-extra.yaml
@@ -1,7 +1,7 @@
 template_path: app-extra.yaml
 stack_name: synapse-login-bmgfki-extra
 dependencies:
-  - bmgfki/synapse-login-bmgfki-sageit-cert.yaml
+  - bmgfki/synapse-login-bmgfki.yaml
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/bmgfki/synapse-login-bmgfki-extra.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-extra.yaml
@@ -1,0 +1,14 @@
+template_path: app-extra.yaml
+stack_name: synapse-login-bmgfki-extra
+dependencies:
+  - bmgfki/synapse-login-bmgfki-sageit-cert.yaml
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  Listener80Arn: "arn:aws:elasticloadbalancing:us-east-1:423819316185:listener/app/awseb-AWSEB-WA85KZ8T07CD/db78aedcc9d399a4/ba64e1f5f8596981"
+  Listener443Arn: "arn:aws:elasticloadbalancing:us-east-1:423819316185:listener/app/awseb-AWSEB-WA85KZ8T07CD/db78aedcc9d399a4/7ab27214720751b9"
+  HttpRedirectTarget: "synapse-login-bmgfki.sagebio-bmgfki.org"
+  FriendlyEndpoint: "bmgfki.sc.sageit.org"
+  CertificateArn: !stack_output_external synapse-login-bmgfki-sageit-cert::SSLCertificateSageIT

--- a/config/bmgfki/synapse-login-bmgfki-extra.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-extra.yaml
@@ -7,8 +7,8 @@ stack_tags:
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
 parameters:
-  Listener80Arn: "arn:aws:elasticloadbalancing:us-east-1:423819316185:listener/app/awseb-AWSEB-WA85KZ8T07CD/db78aedcc9d399a4/ba64e1f5f8596981"
-  Listener443Arn: "arn:aws:elasticloadbalancing:us-east-1:423819316185:listener/app/awseb-AWSEB-WA85KZ8T07CD/db78aedcc9d399a4/7ab27214720751b9"
+  Listener80Arn: "arn:aws:elasticloadbalancing:us-east-1:464102568320:listener/app/awseb-AWSEB-19RY2RJRIE8Y8/d53373834f4bcc66/d5661332bacdd51a"
+  Listener443Arn: "arn:aws:elasticloadbalancing:us-east-1:464102568320:listener/app/awseb-AWSEB-19RY2RJRIE8Y8/d53373834f4bcc66/c8b80b5beb1d43aa"
   HttpRedirectTarget: "synapse-login-bmgfki.sagebio-bmgfki.org"
   FriendlyEndpoint: "bmgfki.sc.sageit.org"
   CertificateArn: !stack_output_external synapse-login-bmgfki-sageit-cert::SSLCertificateSageIT

--- a/config/bmgfki/synapse-login-bmgfki-params.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-params.yaml
@@ -1,0 +1,33 @@
+template_path: remote/ssm-parameters.j2
+stack_name: synapse-login-bmgfki-params
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+sceptre_user_data:
+  Prefix: /service-catalog/
+  Parameters  :
+    - Name: SynapseOauthClientId
+      Value: 100105
+    - Name: AwsRegion
+      Value: us-east-1
+    - Name: SessionTimeoutSeconds
+      Value: 28800
+    - Name: SessionNameClaims
+      Value: userid
+    - Name: SessionTagClaims
+      Value: sub,userid,team,user_name,company,given_name,family_name
+    - Name: RedirectUris
+      Value: https://synapse-login-bmgfki.sagebio-bmgfki.org/synapse,https://connect.sagebio-bmgfki.org/oauth2/idpresponse
+    # Synapse team mapping
+    # 3407239 scipool-admin
+    # 3412678 ampad-workinggroup
+    - Name: TeamToRoleArnMap
+      Value: >-
+        '[
+          {"teamId":"3407239","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogEndusers"},
+          {"teamId":"3412678","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogExternalEndusers"}
+        ]'

--- a/config/bmgfki/synapse-login-bmgfki-params.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-params.yaml
@@ -24,10 +24,10 @@ sceptre_user_data:
       Value: https://synapse-login-bmgfki.sagebio-bmgfki.org/synapse,https://connect.sagebio-bmgfki.org/oauth2/idpresponse
     # Synapse team mapping
     # 3407239 scipool-admin
-    # 3412678 ampad-workinggroup
+    # 3432633 BMGFKI_ServiceCatalogUsers
     - Name: TeamToRoleArnMap
       Value: >-
         '[
           {"teamId":"3407239","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogEndusers"},
-          {"teamId":"3412678","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogExternalEndusers"}
+          {"teamId":"3432633","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogExternalEndusers"}
         ]'

--- a/config/bmgfki/synapse-login-bmgfki-sageit-cert.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-sageit-cert.yaml
@@ -1,0 +1,8 @@
+template_path: SageItCert.yaml
+stack_name: synapse-login-bmgfki-sageit-cert
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  DomainName: "*.sc.sageit.org"

--- a/config/bmgfki/synapse-login-bmgfki.yaml
+++ b/config/bmgfki/synapse-login-bmgfki.yaml
@@ -1,0 +1,24 @@
+template_path: app.yaml
+stack_name: synapse-login-bmgfki
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - bmgfki/synapse-login-bmgfki-params.yaml
+  - bmgfki/synapse-login-bmgfki-base.yaml
+parameters:
+  AppDeployBucketName: "org-sagebase-bmgfki-synapse-login-bmgfki"
+  SnsBounceNotificationEndpoint: "aws.bmgfki@sagebase.org"
+  SnsNotificationEndpoint: "aws.bmgfki@sagebase.org"
+  DNSHostname: "synapse-login-bmgfki"
+  DNSDomain: "sagebio-bmgfki.org"
+  EC2InstanceType: "t3.small"
+  EC2KeyName: 'scipool'
+  VpcName: "gatespoolvpc"
+  SolutionStackName: '64bit Amazon Linux 2018.03 v3.4.10 running Tomcat 8.5 Java 8'
+  AutoScalingMinSize: "2"
+  AutoScalingMaxSize: "3"
+  RollingUpdateType: "Health"
+  OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"
+  SsmParameterPrefix: !stack_output_external synapse-login-bmgfki-params::Prefix


### PR DESCRIPTION
These CFN templates will setup the following for an BMGF service catalog

* Setup parameter store and set BMGF params
* Setup Beanstalk for application
* Setup https certificates
* Setup DNS for application

depends on https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/260