### PR TITLE
Fix service user permission for beanstalk

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -461,6 +461,7 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
 Outputs:
   AppPublicEndpoint:
     Value: !Join


### PR DESCRIPTION
Something changed with AdministratorAccess-AWSElasticBeanstalk policy so
that it no longer has access to S3 buckets[1].  The proposed workaround
is to allow ListBucketMultipartUploads to the user policy which I tried
but it didn't work.  In fact giving entire '*' access to the
AppDeployBucketManagedPolicy didn't work either.  AWS keeps returning
the same error.  The only thing that seemed to work was giving the
service user AmazonS3FullAccess permission.

