### PR TITLE
SC-366: adding a new internal Sage team for the STRIDES S.C.

### DIFF
--- a/config/strides/synapse-login-strides-params.yaml
+++ b/config/strides/synapse-login-strides-params.yaml
@@ -29,5 +29,6 @@ sceptre_user_data:
       Value: >-
         '[
           {"teamId":"3407239","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogEndusers"},
+          {"teamId":"3438230","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogEndusers"},
           {"teamId":"3412678","roleArn":"arn:aws:iam::423819316185:role/ServiceCatalogExternalEndusers"}
         ]'

--- a/config/strides/synapse-login-strides-params.yaml
+++ b/config/strides/synapse-login-strides-params.yaml
@@ -24,6 +24,7 @@ sceptre_user_data:
       Value: https://synapse-login-strides.sagebio-strides.org/synapse,https://connect.sagebio-strides.org/oauth2/idpresponse
     # Synapse team mapping
     # 3407239 scipool-admin
+    # 3438230 AMPAD_WG_ServiceCatalogSageInternalUsers
     # 3412678 ampad-workinggroup
     - Name: TeamToRoleArnMap
       Value: >-


### PR DESCRIPTION

Adding a new internal Sage team for the STRIDES S.C.

The new team will map to the `ServiceCatalogEndusers` IAM role, allowing internal Sage users to manage buckets as well as EC2 instances in STRIDES.