### PR TITLE
[SC-378] Use cryptographically strong TLS protocol

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -217,6 +217,10 @@ Resources:
         - Namespace: 'aws:elbv2:listener:443'
           OptionName: Protocol
           Value: HTTPS
+        # ELB cipher and TLS protocol versions
+        - Namespace: 'aws:elbv2:listener:443'
+          OptionName: SSLPolicy
+          Value: ELBSecurityPolicy-TLS-1-2-2017-01
         - Namespace: 'aws:elbv2:listener:443'
           OptionName: SSLCertificateArns
           Value: !ImportValue


### PR DESCRIPTION
By default AWS load balancers use TLSv1.0. Our security auditor
recommends disabling the use of TLSv1.0 protocol in favor of a
cryptographically stronger TLSv1.2 protocol.

Note- TLS1.0 is compatible with a broader set of clients
(such as web browsers, mobile devices, and point-of-sale systems).

References:
https://aws.amazon.com/blogs/security/how-to-control-tls-ciphers-in-your-aws-elastic-beanstalk-application-by-using-aws-cloudformation/
https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
