### PR TITLE
Fix deployment dependency

### DIFF
--- a/config/develop/synapse-login-scipooldev-base.yaml
+++ b/config/develop/synapse-login-scipooldev-base.yaml
@@ -4,6 +4,8 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
+dependencies:
+  - develop/synapse-login-scipooldev-sageit-cert.yaml
 parameters:
   DNSDomainName: "scipooldev.org"
   BeanstalkAppName: "synapse-login"

--- a/config/develop/synapse-login-scipooldev-extra.yaml
+++ b/config/develop/synapse-login-scipooldev-extra.yaml
@@ -1,7 +1,7 @@
 template_path: app-extra.yaml
 stack_name: synapse-login-scipooldev-extra
 dependencies:
-  - develop/synapse-login-scipooldev-sageit-cert.yaml
+  - develop/synapse-login-scipooldev.yaml
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/prod/synapse-login-scipoolprod-base.yaml
+++ b/config/prod/synapse-login-scipoolprod-base.yaml
@@ -4,6 +4,8 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
+dependencies:
+  - prod/synapse-login-scipoolprod-sageit-cert.yaml
 parameters:
   DNSDomainName: "scipoolprod.org"
   BeanstalkAppName: "synapse-login"

--- a/config/prod/synapse-login-scipoolprod-extra.yaml
+++ b/config/prod/synapse-login-scipoolprod-extra.yaml
@@ -1,7 +1,7 @@
 template_path: app-extra.yaml
 stack_name: synapse-login-scipoolprod-extra
 dependencies:
-  - prod/synapse-login-scipoolprod-sageit-cert.yaml
+  - prod/synapse-login-scipoolprod.yaml
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/strides/synapse-login-strides-base.yaml
+++ b/config/strides/synapse-login-strides-base.yaml
@@ -4,6 +4,8 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
+dependencies:
+  - strides/synapse-login-strides-sageit-cert.yaml
 parameters:
   DNSDomainName: "sagebio-strides.org"
   BeanstalkAppName: "synapse-login"

--- a/config/strides/synapse-login-strides-extra.yaml
+++ b/config/strides/synapse-login-strides-extra.yaml
@@ -1,7 +1,7 @@
 template_path: app-extra.yaml
 stack_name: synapse-login-strides-extra
 dependencies:
-  - strides/synapse-login-strides-sageit-cert.yaml
+  - strides/synapse-login-strides.yaml
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"


### PR DESCRIPTION
The template dependencies were not correct which may have caused the
deployment failure.  This is an attempt to put the dependencies in the
correct state.
