### PR TITLE
Use sceptre template handlers

### DIFF
--- a/config/bmgfki/synapse-login-bmgfki-params.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-params.yaml
@@ -1,8 +1,7 @@
-template_path: remote/ssm-parameters.j2
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2"
 stack_name: synapse-login-bmgfki-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/develop/synapse-login-scipooldev-params.yaml
+++ b/config/develop/synapse-login-scipooldev-params.yaml
@@ -1,8 +1,7 @@
-template_path: remote/ssm-parameters.j2
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2"
 stack_name: synapse-login-scipooldev-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -1,8 +1,7 @@
-template_path: remote/ssm-parameters.j2
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2"
 stack_name: synapse-login-scipoolprod-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/strides/synapse-login-strides-params.yaml
+++ b/config/strides/synapse-login-strides-params.yaml
@@ -1,8 +1,7 @@
-template_path: remote/ssm-parameters.j2
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2"
 stack_name: synapse-login-strides-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"


### PR DESCRIPTION
* Pin to specific version of remote templates
* Sceptre supports template handlers[1] to get remote templates so we no
  longer need to use hooks. Convert all hooks to template handler.

[1] https://docs.sceptre-project.org/dev/docs/template_handlers.html

