### PR TITLE
use updated ssm template

### DIFF
--- a/config/bmgfki/synapse-login-bmgfki-params.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-params.yaml
@@ -1,5 +1,5 @@
 template:
-  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.3/templates/SystemsManager/ssm-parameters.j2"
 stack_name: "synapse-login-bmgfki-params"
 stack_tags:
   Department: "Platform"

--- a/config/bmgfki/synapse-login-bmgfki-params.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-params.yaml
@@ -1,9 +1,6 @@
 template:
-  path: remote/ssm-parameters.j2
-stack_name: synapse-login-bmgfki-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+stack_name: "synapse-login-bmgfki-params"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/develop/synapse-login-scipooldev-params.yaml
+++ b/config/develop/synapse-login-scipooldev-params.yaml
@@ -1,5 +1,5 @@
 template:
-  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.3/templates/SystemsManager/ssm-parameters.j2"
 stack_name: "synapse-login-scipooldev-params"
 stack_tags:
   Department: "Platform"

--- a/config/develop/synapse-login-scipooldev-params.yaml
+++ b/config/develop/synapse-login-scipooldev-params.yaml
@@ -1,9 +1,6 @@
 template:
-  path: remote/ssm-parameters.j2
-stack_name: synapse-login-scipooldev-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+stack_name: "synapse-login-scipooldev-params"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -1,9 +1,6 @@
 template:
-  path: remote/ssm-parameters.j2
-stack_name: synapse-login-scipoolprod-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+stack_name: "synapse-login-scipoolprod-params"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -1,5 +1,5 @@
 template:
-  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.3/templates/SystemsManager/ssm-parameters.j2"
 stack_name: "synapse-login-scipoolprod-params"
 stack_tags:
   Department: "Platform"

--- a/config/strides/synapse-login-strides-params.yaml
+++ b/config/strides/synapse-login-strides-params.yaml
@@ -1,9 +1,6 @@
 template:
-  path: remote/ssm-parameters.j2
-stack_name: synapse-login-strides-params
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.7/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+stack_name: "synapse-login-strides-params"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/strides/synapse-login-strides-params.yaml
+++ b/config/strides/synapse-login-strides-params.yaml
@@ -1,5 +1,5 @@
 template:
-  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.2/templates/SystemsManager/ssm-parameters.j2"
+  path: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.3/templates/SystemsManager/ssm-parameters.j2"
 stack_name: "synapse-login-strides-params"
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
Use the updated template that disables auto escaping characters.
This makes it so that we don't need to use hooks as a workaround
for issue in discussion https://github.com/Sceptre/sceptre/discussions/1238

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/346

