### PR TITLE
[IT-2226] Enable patching for beanstalk

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -118,6 +118,16 @@ Resources:
       SolutionStackName: !Ref SolutionStackName
       OptionSettings:
         # EB environment options
+        - Namespace: 'aws:elasticbeanstalk:managedactions'
+          OptionName: ManagedActionsEnabled
+          Value: 'true'
+        - Namespace: 'aws:elasticbeanstalk:managedactions'
+          OptionName: PreferredStartTime
+          Value: 'Tue:09:00'
+        - Namespace: 'aws:elasticbeanstalk:managedactions'
+          OptionName: ServiceRoleForManagedUpdates
+          Value: !ImportValue
+                 'Fn::Sub': '${AWS::Region}-${AWS::StackName}-base-BeanstalkServiceRole'
         - Namespace: 'aws:elasticbeanstalk:managedactions:platformupdate'
           OptionName: UpdateLevel
           Value: !Ref ManagedPlatformUpdateLevel


### PR DESCRIPTION
PR #80 to setup beanstalk patching was incomplete. We also need to set the aws:elasticbeanstalk:managedactions[1].

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactions
