### PR TITLE
[IT-2226] Enable enhanced health reporting

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -26,7 +26,7 @@ Parameters:
     MaxValue: 2
   BeanstalkHealthReportingSystem:
     Type: String
-    Default: basic
+    Default: enhanced
     AllowedValues:
       - basic
       - enhanced


### PR DESCRIPTION
AWS beanstalk says that managed solution stack updates requires enabling enhanced health reporting.

```
[2022-10-24 22:08:31] - develop/synapse-login-scipooldev BeanstalkConfigurationTemplate
AWS::ElasticBeanstalk::ConfigurationTemplate UPDATE_FAILED Configuration validation exception:
Invalid option specification (Namespace: 'aws:elasticbeanstalk:managedactions', OptionName: 'ManagedActionsEnabled'):
Managed platform updates require enhanced health reporting (option SystemType in namespace aws:elasticbeanstalk:healthreporting:system).
(Service: AWSElasticBeanstalk; Status Code: 400; Error Code: ConfigurationValidationException; Request ID: 7fa125ea-ac90-444a-a883-56a84b5bedbc; Proxy: null)
```

