### PR TITLE
[IT-2221] Add source restriction for SSH connections

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -88,6 +88,10 @@ Parameters:
     Description: 'The SSM parameter store prefix for the application variablex'
     ConstraintDescription: 'A prefix to the params (i.e. /service-catalog/)'
     Type: String
+  VpnCidr:
+    Type: String
+    Description: The VPN subnet in CIDR format
+    Default: '10.50.0.0/16'
 Resources:
   LoadBalancerAccessLogsBucket:
     Type: 'AWS::S3::Bucket'
@@ -149,6 +153,9 @@ Resources:
         - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: EC2KeyName
           Value: !Ref EC2KeyName
+        - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: SSHSourceRestriction
+          Value: !Sub 'tcp, 22, 22, ${VpnCidr}'
         - Namespace: 'aws:autoscaling:updatepolicy:rollingupdate'
           OptionName: RollingUpdateEnabled
           Value: 'true'


### PR DESCRIPTION
By default Beanstalk will create a security group that allows ssh connections from any host into the vpc. We can't prevent Beanstalk from creating the security group with an SSH rule, but we can restrict the source. Restrict ssh to only allow connections from localhost.
