### PR TITLE
IT-2718 Add white list for SORC project members

### DIFF
--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -26,11 +26,13 @@ sceptre_user_data:
     #  273957 Sage Bionetworks
     # 3409010 scipoolprod-internal
     # 3409011 scipoolprod-external
+    # 3469335 Schwannomatosis Open Research Collaborative Service Catalog Users
     - Name: TeamToRoleArnMap
       Value: >-
         '[
           {"teamId":"3407239","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
-          {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
+          {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"},
+          {"teamId":"3469335","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
         ]'


### PR DESCRIPTION
IT-2718 needs a group of users outside of Sage to access Service Catalog to provision EC2 instances.  This change adds a new Synapse team, mapped to the `ServiceCatalogExternalEndusers` role.
