### PR TITLE
IT-2718 and IT-2767: Adding two new white list groups

### DIFF
--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -26,7 +26,7 @@ sceptre_user_data:
     #  273957 Sage Bionetworks
     # 3409010 scipoolprod-internal
     # 3409011 scipoolprod-external
-    # 3469335 Schwannomatosis Open Research Collaborative Service Catalog Users
+    # 3451917 SWNTS (Schwannomatosis Open Research Collaborative)
     - Name: TeamToRoleArnMap
       Value: >-
         '[
@@ -34,5 +34,5 @@ sceptre_user_data:
           {"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"},
-          {"teamId":"3469335","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
+          {"teamId":"3451917","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
         ]'

--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -26,11 +26,13 @@ sceptre_user_data:
     #  273957 Sage Bionetworks
     # 3409010 scipoolprod-internal
     # 3409011 scipoolprod-external
+    # 3469335 Schwannomatosis Open Research Collaborative Service Catalog Users
     - Name: TeamToRoleArnMap
       Value: >-
         '[
           {"teamId":"3407239","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
-          {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
+          {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"},
+          {"teamId":"3469335","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
         ]'

--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -25,7 +25,6 @@ sceptre_user_data:
     # 3407239 scipool-admin
     #  273957 Sage Bionetworks
     # 3409010 scipoolprod-internal
-    # 3412679 ampad-portalusers
     # 3409011 scipoolprod-external
     - Name: TeamToRoleArnMap
       Value: >-
@@ -33,6 +32,5 @@ sceptre_user_data:
           {"teamId":"3407239","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
-          {"teamId":"3412679","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"},
           {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
         ]'

--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -27,6 +27,7 @@ sceptre_user_data:
     # 3409010 scipoolprod-internal
     # 3409011 scipoolprod-external
     # 3451917 SWNTS (Schwannomatosis Open Research Collaborative)
+    # 3469336 RECOVER Service Catalog External Users
     - Name: TeamToRoleArnMap
       Value: >-
         '[
@@ -34,5 +35,6 @@ sceptre_user_data:
           {"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"},
           {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"},
-          {"teamId":"3451917","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}
+          {"teamId":"3451917","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"},
+          {"teamId":"3469336","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}
         ]'

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -478,7 +478,6 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - !ImportValue {'Fn::Sub': '${AWS::Region}-bootstrap-TravisUserArn'}
                 - !GetAtt ServiceUser.Arn
             Action:
               - "sts:AssumeRole"


### PR DESCRIPTION
IT-2718 requires a new white list group, 3451917.
IT-2767 requires the group, 3469336.
These additions have been made in `dev` already.
This PR updates `prod` with the changes.
