### PR TITLE
fix long session name

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           aws-region: ${{ inputs.aws-region }}
           role-to-assume: ${{ inputs.role-to-assume }}
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
       - name: Deploy with sceptre
         run: |


### PR DESCRIPTION
fix error..

```
rror: 1 validation error detected: Value
'GitHubActions-Sage-Bionetworks-synapse-login-aws-infra-6328535604'
at 'roleSessionName' failed to satisfy constraint:
Member must have length less than or equal to 64
```
