### PR TITLE
Increase storage on EC2 instances

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -56,6 +56,12 @@ Parameters:
       - t3.large
       - t3.xlarge
       - t3.2xlarge
+  RootVolumeSize:
+    Type: Number
+    Description: Volume size for Elastic Beanstalk Instances
+    Default: "60"
+    MinValue: "30"
+    MaxValue: "200"
   EC2KeyName:
     Description: An existing EC2 keypair to allow secure access to instances
     Type: String
@@ -143,6 +149,9 @@ Resources:
         - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: InstanceType
           Value: !Ref EC2InstanceType
+        - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: RootVolumeSize
+          Value: !Ref RootVolumeSize
         - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: SecurityGroups
           Value: !Ref InstanceSecurityGroup


### PR DESCRIPTION
We are seeing the following error when deploying the synapse login app[1] to elastic beanstalk..

```
2023/10/04 22:31:39.365868 [ERROR] failed to populate deployment meta data with error
failed to generate App version manifest file with error write
/opt/elasticbeanstalk/deployment/app_version_manifest.json: no space left on device
```

Update the infra template to configure larger volume by default and allow users to override the volume size if needed.

[1] https://github.com/Sage-Bionetworks/synapse-login-scipool

