### PR TITLE
[IT-3110] Remove service user

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -471,29 +471,6 @@ Resources:
           - !Ref 'AWS::StackName'
           - var/log/tomcat8/catalina.out
       RetentionInDays: 90
-  ServiceUser:
-    Type: 'AWS::IAM::User'
-  ServiceUserAccessKey:
-    Type: 'AWS::IAM::AccessKey'
-    Properties:
-      UserName: !Ref ServiceUser
-  ServiceRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - !GetAtt ServiceUser.Arn
-            Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
 Outputs:
   AppPublicEndpoint:
     Value: !Join
@@ -525,30 +502,6 @@ Outputs:
     Value: !Ref InstanceSecurityGroup
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-InstanceSecurityGroup'
-  ServiceUser:
-    Value: !Ref ServiceUser
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUser'
-  ServiceUserArn:
-    Value: !GetAtt ServiceUser.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserArn'
-  ServiceUserAccessKey:
-    Value: !Ref ServiceUserAccessKey
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserAccessKey'
-  ServiceUserSecretAccessKey:
-    Value: !GetAtt ServiceUserAccessKey.SecretAccessKey
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserSecretAccessKey'
-  ServiceRole:
-    Value: !Ref ServiceRole
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRole'
-  ServiceRoleArn:
-    Value: !GetAtt ServiceRole.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRoleArn'
   InstanceRole:
     Value: !Ref InstanceRole
     Export:


### PR DESCRIPTION
We have moved the synapse-login-aws-infra[1] and synapse-login-scipool[2] repos CI system to github actions and are now using github OIDC to deploy to AWS.  Therefore we can now remove the service user that was setup for deployments from travis-ci.

[1] https://github.com/Sage-Bionetworks/synapse-login-aws-infra
[2] https://github.com/Sage-Bionetworks/synapse-login-scipool
