### PR TITLE
IT-3558: Add register 'friendly URLs' as OAuth redirect URIs

### DIFF
--- a/config/bmgfki/synapse-login-bmgfki-params.yaml
+++ b/config/bmgfki/synapse-login-bmgfki-params.yaml
@@ -20,7 +20,7 @@ sceptre_user_data:
     - Name: SessionTagClaims
       Value: sub,userid,team,user_name,company,given_name,family_name
     - Name: RedirectUris
-      Value: https://synapse-login-bmgfki.sagebio-bmgfki.org/synapse,https://connect.sagebio-bmgfki.org/oauth2/idpresponse
+      Value: https://synapse-login-bmgfki.sagebio-bmgfki.org/synapse,https://connect.sagebio-bmgfki.org/oauth2/idpresponse,https://bmgfki.sc.sageit.org/synapse
     # Synapse team mapping
     # 3407239 scipool-admin
     # 3432633 BMGFKI_ServiceCatalogUsers

--- a/config/develop/synapse-login-scipooldev-params.yaml
+++ b/config/develop/synapse-login-scipooldev-params.yaml
@@ -20,7 +20,7 @@ sceptre_user_data:
     - Name: SessionTagClaims
       Value: sub,userid,team,user_name,company,given_name,family_name
     - Name: RedirectUris
-      Value: https://synapse-login-scipooldev.scipooldev.org/synapse,https://connect.scipooldev.org/oauth2/idpresponse
+      Value: https://synapse-login-scipooldev.scipooldev.org/synapse,https://connect.scipooldev.org/oauth2/idpresponse,https://sc-dev.sageit.org/synapse
     # Synapse team mapping:
     # 3407239 scipool-admin
     # 3409012 scipooldev-internal

--- a/config/prod/synapse-login-scipoolprod-params.yaml
+++ b/config/prod/synapse-login-scipoolprod-params.yaml
@@ -20,7 +20,7 @@ sceptre_user_data:
     - Name: SessionTagClaims
       Value: sub,userid,team,user_name,company,given_name,family_name
     - Name: RedirectUris
-      Value: https://synapse-login-scipoolprod.scipoolprod.org/synapse,https://connect.scipoolprod.org/oauth2/idpresponse
+      Value: https://synapse-login-scipoolprod.scipoolprod.org/synapse,https://connect.scipoolprod.org/oauth2/idpresponse,https://sc.sageit.org/synapse
     # Synapse team mapping
     # 3407239 scipool-admin
     #  273957 Sage Bionetworks

--- a/config/strides/synapse-login-strides-params.yaml
+++ b/config/strides/synapse-login-strides-params.yaml
@@ -20,7 +20,7 @@ sceptre_user_data:
     - Name: SessionTagClaims
       Value: sub,userid,team,user_name,company,given_name,family_name
     - Name: RedirectUris
-      Value: https://synapse-login-strides.sagebio-strides.org/synapse,https://connect.sagebio-strides.org/oauth2/idpresponse
+      Value: https://synapse-login-strides.sagebio-strides.org/synapse,https://connect.sagebio-strides.org/oauth2/idpresponse,https://ad.strides.sc.sageit.org/synapse
     # Synapse team mapping
     # 3407239 scipool-admin
     # 3438230 AMPAD_WG_ServiceCatalogSageInternalUsers


### PR DESCRIPTION
Today, Synapse will not allow OAuth logins initiated from 'friendly urls' like https://sc.sageit.org.  This change "publishes" the URLs under the common OIDC "sector identifier" for Service Catalog.

Once this is deployed, the new URLs can be registered as valid redirect URIs for the corresponding Synapse OIDC/OAuth clients.  More details [here](https://sagebionetworks.jira.com/browse/SC-208)