### PR TITLE
[IT-4462] Update instance policy

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -448,6 +448,7 @@ Resources:
         - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier'
         - 'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSESFullAccess'
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Ref AppDeployBucketManagedPolicy
         - !Ref CloudwatchIntegrationManagedPolicy
         - !ImportValue


### PR DESCRIPTION
Update EC2 instance policy to allow accessing the EC2 using the AWS systems manager session manager.  This will allow shell access to the EC2 for debugging.

