### PR TITLE
[IT-4462] Update to a supported Beanstalk solution stack

### DIFF
--- a/config/develop/synapse-login-scipooldev-extra.yaml
+++ b/config/develop/synapse-login-scipooldev-extra.yaml
@@ -7,5 +7,5 @@ stack_tags:
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
 parameters:
-  Listener443Arn: "arn:aws:elasticloadbalancing:us-east-1:465877038949:listener/app/awseb--AWSEB-mbSwlQBlKNg7/40f0031b197b4c01/3f6867b248537acb"
+  Listener443Arn: "arn:aws:elasticloadbalancing:us-east-1:465877038949:listener/app/awseb--AWSEB-9bJJo8ZnrhVb/271a6732f7deceb3/90917e640efec0b6"
   CertificateArn: !stack_output_external synapse-login-scipooldev-sageit-cert::SSLCertificateSageIT

--- a/config/develop/synapse-login-scipooldev.yaml
+++ b/config/develop/synapse-login-scipooldev.yaml
@@ -21,3 +21,4 @@ parameters:
   RollingUpdateType: "Health"
   OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"
   SsmParameterPrefix: !stack_output_external synapse-login-scipooldev-params::Prefix
+  SolutionStackName: "64bit Amazon Linux 2 v4.9.8 running Tomcat 9 Corretto 8"

--- a/config/prod/synapse-login-scipoolprod.yaml
+++ b/config/prod/synapse-login-scipoolprod.yaml
@@ -21,3 +21,4 @@ parameters:
   RollingUpdateType: "Health"
   OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"
   SsmParameterPrefix: !stack_output_external synapse-login-scipoolprod-params::Prefix
+  SolutionStackName: "64bit Amazon Linux 2 v4.2.18 running Tomcat 8.5 Corretto 8"

--- a/config/strides/synapse-login-strides.yaml
+++ b/config/strides/synapse-login-strides.yaml
@@ -21,3 +21,4 @@ parameters:
   RollingUpdateType: "Health"
   OidcClientSecretKeyName: "/service-catalog/SynapseOauthClientSecret"
   SsmParameterPrefix: !stack_output_external synapse-login-strides-params::Prefix
+  SolutionStackName: "64bit Amazon Linux 2 v4.2.18 running Tomcat 8.5 Corretto 8"

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -86,7 +86,7 @@ Parameters:
   SolutionStackName:
     Type: String
     Description: The Beanstalk solution stack for the app
-    Default: '64bit Amazon Linux 2 v4.9.5 running Tomcat 9 Corretto 8'
+    Default: '64bit Amazon Linux 2 v4.9.8 running Tomcat 9 Corretto 8'
   OidcClientSecretKeyName:
     Description: 'The name of the key that stores the OAuth 2.0 client secret'
     Type: String

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -86,7 +86,6 @@ Parameters:
   SolutionStackName:
     Type: String
     Description: The Beanstalk solution stack for the app
-    Default: '64bit Amazon Linux 2 v4.9.8 running Tomcat 9 Corretto 8'
   OidcClientSecretKeyName:
     Description: 'The name of the key that stores the OAuth 2.0 client secret'
     Type: String

--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -86,7 +86,7 @@ Parameters:
   SolutionStackName:
     Type: String
     Description: The Beanstalk solution stack for the app
-    Default: '64bit Amazon Linux 2 v4.2.18 running Tomcat 8.5 Corretto 8'
+    Default: '64bit Amazon Linux 2 v4.9.5 running Tomcat 9 Corretto 8'
   OidcClientSecretKeyName:
     Description: 'The name of the key that stores the OAuth 2.0 client secret'
     Type: String
@@ -269,7 +269,7 @@ Resources:
           Value: "ssm::/service-catalog/SynapseOauthClientId"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: AWS_REGION
-          Value: "ssm::/service-catalog/AwsRegion"
+          Value: "us-east-1"
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SESSION_TIMEOUT_SECONDS
           Value: "ssm::/service-catalog/SessionTimeoutSeconds"


### PR DESCRIPTION
* Update to an AWS supported solution stack for `develop` environment

* Changing the solution stack required destroying and re-creation of the
beanstalk environment which created a new load balancer. Updated the
reference to the new load balancer.

* There is a circular dependency in the Sage-Bionetworks/synapse-login-scipool code
when using the ssm client to get the region info from the SSM. The SSM client needs
the region of the SSM before it can be used to lookup a value from the SSM.
Instead of getting the region info from the SSM we change the AWS_REGION ENV
variable to contain the direct region value.
