### PR TITLE
[IT-4462] elastic beanstalk auto update

### DIFF
--- a/templates/app.yaml
+++ b/templates/app.yaml
@@ -284,6 +284,16 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: TEAM_TO_ROLE_ARN_MAP
           Value: "ssm::/service-catalog/TeamToRoleArnMap"
+        # Enable Managed Platform or solution stack Updates
+        - Namespace: aws:elasticbeanstalk:managedactions
+          OptionName: ManagedActionsEnabled
+          Value: "true"
+        - Namespace: aws:elasticbeanstalk:managedactions:platformupdate
+          OptionName: UpdateLevel
+          Value: "minor"
+        - Namespace: aws:elasticbeanstalk:managedactions
+          OptionName: PreferredStartTime
+          Value: "Sun:03:00"
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
Setup elastic beanstalk to automatically update the managed platform (or solution stack) so that we can stay on a supported solution stack.  Configure it to update on minor releases and configure the maintenance window to sundays at 3am.
